### PR TITLE
refactor: use gh project link/unlink

### DIFF
--- a/__tests__/copy-project.test.ts
+++ b/__tests__/copy-project.test.ts
@@ -178,7 +178,7 @@ describe('copyProjectAction', () => {
     expect(copyProjectActionSpy).toHaveReturned();
     expect(linkProjectToRepository).toHaveBeenCalledTimes(1);
     expect(linkProjectToRepository).toHaveBeenCalledWith(
-      newProjectId,
+      newProjectNumber.toString(),
       repository
     );
   });
@@ -198,7 +198,10 @@ describe('copyProjectAction', () => {
     await index.copyProjectAction();
     expect(copyProjectActionSpy).toHaveReturned();
     expect(linkProjectToTeam).toHaveBeenCalledTimes(1);
-    expect(linkProjectToTeam).toHaveBeenCalledWith(newProjectId, team);
+    expect(linkProjectToTeam).toHaveBeenCalledWith(
+      newProjectNumber.toString(),
+      team
+    );
   });
 
   it('does not get draft issues if no template view', async () => {

--- a/__tests__/link-project.test.ts
+++ b/__tests__/link-project.test.ts
@@ -106,7 +106,7 @@ describe('linkProjectAction', () => {
 
     expect(linkProjectToRepository).toHaveBeenCalledTimes(1);
     expect(linkProjectToRepository).toHaveBeenLastCalledWith(
-      projectId,
+      projectNumber,
       repository,
       true
     );
@@ -131,7 +131,11 @@ describe('linkProjectAction', () => {
     expect(linkProjectActionSpy).toHaveReturned();
 
     expect(linkProjectToTeam).toHaveBeenCalledTimes(1);
-    expect(linkProjectToTeam).toHaveBeenLastCalledWith(projectId, team, true);
+    expect(linkProjectToTeam).toHaveBeenLastCalledWith(
+      projectNumber,
+      team,
+      true
+    );
     expect(core.setOutput).toHaveBeenCalledTimes(2);
     expect(core.setOutput).toHaveBeenCalledWith('team-id', teamId);
     expect(core.setOutput).toHaveBeenCalledWith('project-id', projectId);
@@ -149,7 +153,11 @@ describe('linkProjectAction', () => {
     expect(linkProjectActionSpy).toHaveReturned();
 
     expect(linkProjectToTeam).toHaveBeenCalledTimes(1);
-    expect(linkProjectToTeam).toHaveBeenLastCalledWith(projectId, team, false);
+    expect(linkProjectToTeam).toHaveBeenLastCalledWith(
+      projectNumber,
+      team,
+      false
+    );
     expect(core.setOutput).toHaveBeenCalledTimes(2);
     expect(core.setOutput).toHaveBeenCalledWith('team-id', teamId);
     expect(core.setOutput).toHaveBeenCalledWith('project-id', projectId);

--- a/dist/add-item.js
+++ b/dist/add-item.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/archive-item.js
+++ b/dist/archive-item.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/close-project.js
+++ b/dist/close-project.js
@@ -21914,7 +21914,7 @@ var core = __toESM(require_core());
 var exec = __toESM(require_exec());
 var tc = __toESM(require_tool_cache());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/completed-by.js
+++ b/dist/completed-by.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/copy-project.js
+++ b/dist/copy-project.js
@@ -23838,7 +23838,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {
@@ -24156,7 +24156,7 @@ async function editProject(owner, projectNumber, edit) {
   }
   return JSON.parse(output).id;
 }
-async function linkProjectToRepository(projectId, repository, linked = true) {
+async function linkProjectToRepository(projectNumber, repository, linked = true) {
   const octokit = getOctokit();
   const [owner, name] = repository.split("/");
   let repositoryId;
@@ -24179,33 +24179,21 @@ async function linkProjectToRepository(projectId, repository, linked = true) {
     throw error2;
   }
   try {
-    await octokit.graphql(
-      `mutation ($projectId: ID!, $repositoryId: ID!) {
-        ${linked ? "linkProjectV2ToRepository" : "unlinkProjectV2FromRepository"}(
-          input: {projectId: $projectId, repositoryId: $repositoryId}
-        ) {
-          repository {
-            id
-          }
-        }
-      }`,
-      { projectId, repositoryId }
-    );
+    await execCliCommand([
+      "project",
+      linked ? "link" : "unlink",
+      projectNumber,
+      "--owner",
+      owner,
+      "--repo",
+      name
+    ]);
   } catch (error2) {
-    if (error2 instanceof import_graphql.GraphqlResponseError) {
-      if (error2.errors?.[0].type === "NOT_FOUND") {
-        if (error2.errors[0].message === `Could not resolve to a node with the global id of '${projectId}'`) {
-          throw new ProjectNotFoundError(error2);
-        } else if (error2.errors[0].message === `Could not resolve to a node with the global id of '${repositoryId}'`) {
-          throw new RepositoryNotFoundError(error2);
-        }
-      }
-    }
-    throw error2;
+    handleCliError(error2);
   }
   return repositoryId;
 }
-async function linkProjectToTeam(projectId, team, linked = true) {
+async function linkProjectToTeam(projectNumber, team, linked = true) {
   const octokit = getOctokit();
   const [owner, name] = team.split("/");
   let teamId;
@@ -24232,29 +24220,17 @@ async function linkProjectToTeam(projectId, team, linked = true) {
     throw error2;
   }
   try {
-    await octokit.graphql(
-      `mutation ($projectId: ID!, $teamId: ID!) {
-        ${linked ? "linkProjectV2ToTeam" : "unlinkProjectV2FromTeam"}(
-          input: {projectId: $projectId, teamId: $teamId}
-        ) {
-          team {
-            id
-          }
-        }
-      }`,
-      { projectId, teamId }
-    );
+    await execCliCommand([
+      "project",
+      linked ? "link" : "unlink",
+      projectNumber,
+      "--owner",
+      owner,
+      "--team",
+      name
+    ]);
   } catch (error2) {
-    if (error2 instanceof import_graphql.GraphqlResponseError) {
-      if (error2.errors?.[0].type === "NOT_FOUND") {
-        if (error2.errors[0].message === `Could not resolve to a node with the global id of '${projectId}'`) {
-          throw new ProjectNotFoundError(error2);
-        } else if (error2.errors[0].message === `Could not resolve to a node with the global id of '${teamId}'`) {
-          throw new TeamNotFoundError(error2);
-        }
-      }
-    }
-    throw error2;
+    handleCliError(error2);
   }
   return teamId;
 }
@@ -24294,10 +24270,13 @@ async function copyProjectAction() {
       });
     }
     if (linkToRepository) {
-      await linkProjectToRepository(project.id, linkToRepository);
+      await linkProjectToRepository(
+        project.number.toString(),
+        linkToRepository
+      );
     }
     if (linkToTeam) {
-      await linkProjectToTeam(project.id, linkToTeam);
+      await linkProjectToTeam(project.number.toString(), linkToTeam);
     }
     if (templateView) {
       const draftIssues = await getDraftIssues(project.id);

--- a/dist/delete-item.js
+++ b/dist/delete-item.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/delete-project.js
+++ b/dist/delete-project.js
@@ -21914,7 +21914,7 @@ var core = __toESM(require_core());
 var exec = __toESM(require_exec());
 var tc = __toESM(require_tool_cache());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/edit-item.js
+++ b/dist/edit-item.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/edit-project.js
+++ b/dist/edit-project.js
@@ -21914,7 +21914,7 @@ var core = __toESM(require_core());
 var exec = __toESM(require_exec());
 var tc = __toESM(require_tool_cache());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/find-project.js
+++ b/dist/find-project.js
@@ -21914,7 +21914,7 @@ var core = __toESM(require_core());
 var exec = __toESM(require_exec());
 var tc = __toESM(require_tool_cache());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/get-item.js
+++ b/dist/get-item.js
@@ -23367,7 +23367,7 @@ var tc = __toESM(require_tool_cache());
 var import_core = __toESM(require_dist_node8());
 var import_plugin_paginate_graphql = __toESM(require_dist_node9());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/get-project.js
+++ b/dist/get-project.js
@@ -21914,7 +21914,7 @@ var core = __toESM(require_core());
 var exec = __toESM(require_exec());
 var tc = __toESM(require_tool_cache());
 var GH_CLI_RELEASES = "https://github.com/cli/cli/releases/";
-var GH_VERSION = "2.40.1";
+var GH_VERSION = "2.45.0";
 var GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
   if (process.platform !== "linux") {

--- a/dist/github-script/index.js
+++ b/dist/github-script/index.js
@@ -37484,7 +37484,7 @@ const tc = __importStar(__nccwpck_require__(7784));
 const core_1 = __nccwpck_require__(6762);
 const plugin_paginate_graphql_1 = __nccwpck_require__(5883);
 const GH_CLI_RELEASES = 'https://github.com/cli/cli/releases/';
-const GH_VERSION = '2.40.1';
+const GH_VERSION = '2.45.0';
 const GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 async function installGhCli() {
     if (process.platform !== 'linux') {
@@ -38138,7 +38138,7 @@ exports.getProject = getProject;
  * @throws ProjectNotFoundError
  * @throws RepositoryNotFoundError
  */
-async function linkProjectToRepository(projectId, repository, linked = true) {
+async function linkProjectToRepository(projectNumber, repository, linked = true) {
     const octokit = (0, helpers_1.getOctokit)();
     const [owner, name] = repository.split('/');
     let repositoryId;
@@ -38158,32 +38158,19 @@ async function linkProjectToRepository(projectId, repository, linked = true) {
         }
         throw error;
     }
-    // eslint-disable-next-line no-useless-catch
     try {
-        await octokit.graphql(`mutation ($projectId: ID!, $repositoryId: ID!) {
-        ${linked ? 'linkProjectV2ToRepository' : 'unlinkProjectV2FromRepository'}(
-          input: {projectId: $projectId, repositoryId: $repositoryId}
-        ) {
-          repository {
-            id
-          }
-        }
-      }`, { projectId, repositoryId });
+        await (0, helpers_1.execCliCommand)([
+            'project',
+            linked ? 'link' : 'unlink',
+            projectNumber,
+            '--owner',
+            owner,
+            '--repo',
+            name
+        ]);
     }
     catch (error) {
-        if (error instanceof graphql_1.GraphqlResponseError) {
-            if (error.errors?.[0].type === 'NOT_FOUND') {
-                if (error.errors[0].message ===
-                    `Could not resolve to a node with the global id of '${projectId}'`) {
-                    throw new ProjectNotFoundError(error);
-                }
-                else if (error.errors[0].message ===
-                    `Could not resolve to a node with the global id of '${repositoryId}'`) {
-                    throw new RepositoryNotFoundError(error);
-                }
-            }
-        }
-        throw error;
+        handleCliError(error);
     }
     return repositoryId;
 }
@@ -38192,7 +38179,7 @@ exports.linkProjectToRepository = linkProjectToRepository;
  * @throws ProjectNotFoundError
  * @throws TeamNotFoundError
  */
-async function linkProjectToTeam(projectId, team, linked = true) {
+async function linkProjectToTeam(projectNumber, team, linked = true) {
     const octokit = (0, helpers_1.getOctokit)();
     const [owner, name] = team.split('/');
     let teamId;
@@ -38216,32 +38203,19 @@ async function linkProjectToTeam(projectId, team, linked = true) {
         }
         throw error;
     }
-    // eslint-disable-next-line no-useless-catch
     try {
-        await octokit.graphql(`mutation ($projectId: ID!, $teamId: ID!) {
-        ${linked ? 'linkProjectV2ToTeam' : 'unlinkProjectV2FromTeam'}(
-          input: {projectId: $projectId, teamId: $teamId}
-        ) {
-          team {
-            id
-          }
-        }
-      }`, { projectId, teamId });
+        await (0, helpers_1.execCliCommand)([
+            'project',
+            linked ? 'link' : 'unlink',
+            projectNumber,
+            '--owner',
+            owner,
+            '--team',
+            name
+        ]);
     }
     catch (error) {
-        if (error instanceof graphql_1.GraphqlResponseError) {
-            if (error.errors?.[0].type === 'NOT_FOUND') {
-                if (error.errors[0].message ===
-                    `Could not resolve to a node with the global id of '${projectId}'`) {
-                    throw new ProjectNotFoundError(error);
-                }
-                else if (error.errors[0].message ===
-                    `Could not resolve to a node with the global id of '${teamId}'`) {
-                    throw new TeamNotFoundError(error);
-                }
-            }
-        }
-        throw error;
+        handleCliError(error);
     }
     return teamId;
 }

--- a/src/copy-project.ts
+++ b/src/copy-project.ts
@@ -57,11 +57,14 @@ export async function copyProjectAction(): Promise<void> {
     }
 
     if (linkToRepository) {
-      await linkProjectToRepository(project.id, linkToRepository);
+      await linkProjectToRepository(
+        project.number.toString(),
+        linkToRepository
+      );
     }
 
     if (linkToTeam) {
-      await linkProjectToTeam(project.id, linkToTeam);
+      await linkProjectToTeam(project.number.toString(), linkToTeam);
     }
 
     // Do template interpolation on draft issues

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ import { Octokit } from '@octokit/core';
 import { paginateGraphql } from '@octokit/plugin-paginate-graphql';
 
 const GH_CLI_RELEASES = 'https://github.com/cli/cli/releases/';
-const GH_VERSION = '2.40.1';
+const GH_VERSION = '2.45.0';
 const GH_DEB_FILENAME = `gh_${GH_VERSION}_linux_amd64.tar.gz`;
 
 export async function installGhCli(): Promise<string> {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -878,7 +878,7 @@ export async function getProject(
  * @throws RepositoryNotFoundError
  */
 export async function linkProjectToRepository(
-  projectId: string,
+  projectNumber: string,
   repository: string,
   linked = true
 ): Promise<string> {
@@ -907,40 +907,18 @@ export async function linkProjectToRepository(
     throw error;
   }
 
-  // eslint-disable-next-line no-useless-catch
   try {
-    await octokit.graphql(
-      `mutation ($projectId: ID!, $repositoryId: ID!) {
-        ${
-          linked ? 'linkProjectV2ToRepository' : 'unlinkProjectV2FromRepository'
-        }(
-          input: {projectId: $projectId, repositoryId: $repositoryId}
-        ) {
-          repository {
-            id
-          }
-        }
-      }`,
-      { projectId, repositoryId }
-    );
+    await execCliCommand([
+      'project',
+      linked ? 'link' : 'unlink',
+      projectNumber,
+      '--owner',
+      owner,
+      '--repo',
+      name
+    ]);
   } catch (error) {
-    if (error instanceof GraphqlResponseError) {
-      if (error.errors?.[0].type === 'NOT_FOUND') {
-        if (
-          error.errors[0].message ===
-          `Could not resolve to a node with the global id of '${projectId}'`
-        ) {
-          throw new ProjectNotFoundError(error);
-        } else if (
-          error.errors[0].message ===
-          `Could not resolve to a node with the global id of '${repositoryId}'`
-        ) {
-          throw new RepositoryNotFoundError(error);
-        }
-      }
-    }
-
-    throw error;
+    handleCliError(error);
   }
 
   return repositoryId;
@@ -951,7 +929,7 @@ export async function linkProjectToRepository(
  * @throws TeamNotFoundError
  */
 export async function linkProjectToTeam(
-  projectId: string,
+  projectNumber: string,
   team: string,
   linked = true
 ): Promise<string> {
@@ -983,38 +961,18 @@ export async function linkProjectToTeam(
     throw error;
   }
 
-  // eslint-disable-next-line no-useless-catch
   try {
-    await octokit.graphql(
-      `mutation ($projectId: ID!, $teamId: ID!) {
-        ${linked ? 'linkProjectV2ToTeam' : 'unlinkProjectV2FromTeam'}(
-          input: {projectId: $projectId, teamId: $teamId}
-        ) {
-          team {
-            id
-          }
-        }
-      }`,
-      { projectId, teamId }
-    );
+    await execCliCommand([
+      'project',
+      linked ? 'link' : 'unlink',
+      projectNumber,
+      '--owner',
+      owner,
+      '--team',
+      name
+    ]);
   } catch (error) {
-    if (error instanceof GraphqlResponseError) {
-      if (error.errors?.[0].type === 'NOT_FOUND') {
-        if (
-          error.errors[0].message ===
-          `Could not resolve to a node with the global id of '${projectId}'`
-        ) {
-          throw new ProjectNotFoundError(error);
-        } else if (
-          error.errors[0].message ===
-          `Could not resolve to a node with the global id of '${teamId}'`
-        ) {
-          throw new TeamNotFoundError(error);
-        }
-      }
-    }
-
-    throw error;
+    handleCliError(error);
   }
 
   return teamId;

--- a/src/link-project.ts
+++ b/src/link-project.ts
@@ -22,13 +22,13 @@ export async function linkProjectAction(): Promise<void> {
 
     if (repository) {
       const repositoryId = await linkProjectToRepository(
-        project.id,
+        projectNumber,
         repository,
         linked
       );
       core.setOutput('repository-id', repositoryId);
     } else {
-      const teamId = await linkProjectToTeam(project.id, team, linked);
+      const teamId = await linkProjectToTeam(projectNumber, team, linked);
       core.setOutput('team-id', teamId);
     }
 


### PR DESCRIPTION
Drop the GraphQL mutations in favor of using `gh project [link|unlink]` directly.