### PR TITLE
feat: add fail-if-item-not-found input to more actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -172,12 +172,35 @@ jobs:
           project-number: ${{ steps.copy-project.outputs.number }}
           token: ${{ steps.get-auth-token.outputs.token }}
 
+      - name: Edit Item (Not Found)
+        uses: ./edit-item/
+        id: edit-item-not-found
+        with:
+          fail-if-item-not-found: false
+          field: Priority
+          field-value: ⛰️ High
+          item: foobar
+          owner: ${{ steps.copy-project.outputs.owner }}
+          project-number: ${{ steps.copy-project.outputs.number }}
+          token: ${{ steps.get-auth-token.outputs.token }}
+
       - name: Get Item
         uses: ./get-item/
         id: get-edited-item
         with:
           field: Priority
           item: ${{ steps.edit-item.outputs.id }}
+          owner: ${{ steps.copy-project.outputs.owner }}
+          project-number: ${{ steps.copy-project.outputs.number }}
+          token: ${{ steps.get-auth-token.outputs.token }}
+
+      - name: Get Item (Not Found)
+        uses: ./get-item/
+        id: get-item-not-found
+        with:
+          fail-if-item-not-found: false
+          field: Priority
+          item: foobar
           owner: ${{ steps.copy-project.outputs.owner }}
           project-number: ${{ steps.copy-project.outputs.number }}
           token: ${{ steps.get-auth-token.outputs.token }}
@@ -232,6 +255,16 @@ jobs:
         id: delete-item
         with:
           item: ${{ steps.edit-item.outputs.id }}
+          owner: ${{ steps.copy-project.outputs.owner }}
+          project-number: ${{ steps.copy-project.outputs.number }}
+          token: ${{ steps.get-auth-token.outputs.token }}
+
+      - name: Delete Item (Not Found)
+        uses: ./delete-item/
+        id: delete-item-not-found
+        with:
+          item: foobar
+          fail-if-item-not-found: false
           owner: ${{ steps.copy-project.outputs.owner }}
           project-number: ${{ steps.copy-project.outputs.number }}
           token: ${{ steps.get-auth-token.outputs.token }}

--- a/__tests__/delete-item.test.mts
+++ b/__tests__/delete-item.test.mts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 
 import * as index from '../src/delete-item.js';
 import { ItemDetails, deleteItem, getItem } from '../src/lib.js';
-import { mockGetInput } from './utils.js';
+import { mockGetBooleanInput, mockGetInput } from './utils.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/lib');
@@ -51,6 +51,7 @@ describe('deleteItemAction', () => {
 
   it('handles item not found', async () => {
     mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': true });
     vi.mocked(deleteItem).mockResolvedValue();
 
     await index.deleteItemAction();
@@ -58,6 +59,18 @@ describe('deleteItemAction', () => {
 
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenLastCalledWith(`Item not found: ${item}`);
+  });
+
+  it('can ignore item not found', async () => {
+    mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': false });
+    vi.mocked(getItem).mockResolvedValue(null);
+
+    await index.deleteItemAction();
+    expect(deleteItemActionSpy).toHaveReturned();
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.setOutput).not.toHaveBeenCalled();
   });
 
   it('handles project not found', async () => {

--- a/__tests__/edit-item.test.mts
+++ b/__tests__/edit-item.test.mts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 
 import * as index from '../src/edit-item.js';
 import { ItemDetails, editItem, getItem } from '../src/lib.js';
-import { mockGetInput } from './utils.js';
+import { mockGetBooleanInput, mockGetInput } from './utils.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/lib');
@@ -86,6 +86,7 @@ describe('editItemAction', () => {
 
   it('handles item not found', async () => {
     mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': true });
     vi.mocked(editItem).mockResolvedValue(itemId);
 
     await index.editItemAction();
@@ -93,6 +94,18 @@ describe('editItemAction', () => {
 
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenLastCalledWith(`Item not found: ${item}`);
+  });
+
+  it('can ignore item not found', async () => {
+    mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': false });
+    vi.mocked(getItem).mockResolvedValue(null);
+
+    await index.editItemAction();
+    expect(editItemActionSpy).toHaveReturned();
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.setOutput).not.toHaveBeenCalled();
   });
 
   it('handles project not found', async () => {

--- a/__tests__/get-item.test.mts
+++ b/__tests__/get-item.test.mts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 
 import * as index from '../src/get-item.js';
 import { getItem } from '../src/lib.js';
-import { mockGetInput } from './utils.js';
+import { mockGetBooleanInput, mockGetInput } from './utils.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/lib');
@@ -52,6 +52,7 @@ describe('getItemAction', () => {
 
   it('handles item not found', async () => {
     mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': true });
     vi.mocked(getItem).mockResolvedValue(null);
 
     await index.getItemAction();
@@ -59,6 +60,18 @@ describe('getItemAction', () => {
 
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenLastCalledWith(`Item not found: ${item}`);
+  });
+
+  it('can ignore item not found', async () => {
+    mockGetInput({ owner, 'project-number': projectNumber, item });
+    mockGetBooleanInput({ 'fail-if-item-not-found': false });
+    vi.mocked(getItem).mockResolvedValue(null);
+
+    await index.getItemAction();
+    expect(getItemActionSpy).toHaveReturned();
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.setOutput).not.toHaveBeenCalled();
   });
 
   it('handles project not found', async () => {

--- a/delete-item/README.md
+++ b/delete-item/README.md
@@ -16,6 +16,7 @@ Can not delete archived items due to a bug in the GitHub GraphQL API, see <https
 | `owner`       | The owner of the project - either an organization or a user. If not provided, it defaults to the repository owner. | No       | `${{ github.repository_owner }}`           |
 | `project-number` | The project number from the project's URL.         | Yes      |                                              |
 | `item`        | The item to delete - may be the global ID for the item, the content ID, or the content URL. | No       | `${{ github.event.pull_request.html_url \|\| github.event.issue.html_url }}` |
+| `fail-if-item-not-found` | Should the action fail if the item is not found on the project | No      | `true` |
 
 ## Outputs
 

--- a/delete-item/action.yml
+++ b/delete-item/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: The item to delete - may be the global ID for the item, the content ID, or the content URL
     required: false
     default: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
+  fail-if-item-not-found:
+    description: Should the action fail if the item is not found on the project
+    required: false
+    default: true
 
 runs:
   using: node20

--- a/dist/delete-item.js
+++ b/dist/delete-item.js
@@ -18872,7 +18872,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports2.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput3(name, options);
@@ -18883,7 +18883,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports2.getBooleanInput = getBooleanInput;
+    exports2.getBooleanInput = getBooleanInput2;
     function setOutput(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -23738,9 +23738,10 @@ async function deleteItemAction() {
     const owner = core2.getInput("owner", { required: true });
     const projectNumber = core2.getInput("project-number", { required: true });
     const item = core2.getInput("item", { required: true });
+    const failIfItemNotFound = core2.getBooleanInput("fail-if-item-not-found");
     const fullItem = await getItem(owner, projectNumber, item);
     if (!fullItem) {
-      core2.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core2.setFailed(`Item not found: ${item}`);
       return;
     }
     await deleteItem(owner, projectNumber, fullItem.id);

--- a/dist/edit-item.js
+++ b/dist/edit-item.js
@@ -18872,7 +18872,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports2.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput3(name, options);
@@ -18883,7 +18883,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports2.getBooleanInput = getBooleanInput;
+    exports2.getBooleanInput = getBooleanInput2;
     function setOutput2(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -23871,13 +23871,14 @@ async function editItemAction() {
     const body = core2.getInput("body");
     const field = core2.getInput("field");
     const fieldValue = core2.getInput("field-value", { required: !!field });
+    const failIfItemNotFound = core2.getBooleanInput("fail-if-item-not-found");
     if (!!fieldValue && !field) {
       core2.setFailed("Input required and not supplied: field");
       return;
     }
     const fullItem = await getItem(owner, projectNumber, item);
     if (!fullItem) {
-      core2.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core2.setFailed(`Item not found: ${item}`);
       return;
     }
     if (fullItem.content.type !== "DraftIssue" && (!!title || !!body)) {

--- a/dist/get-item.js
+++ b/dist/get-item.js
@@ -18872,7 +18872,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports2.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput3(name, options);
@@ -18883,7 +18883,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports2.getBooleanInput = getBooleanInput;
+    exports2.getBooleanInput = getBooleanInput2;
     function setOutput2(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -23724,9 +23724,10 @@ async function getItemAction() {
     const projectNumber = core2.getInput("project-number", { required: true });
     const item = core2.getInput("item", { required: true });
     const field = core2.getInput("field") || void 0;
+    const failIfItemNotFound = core2.getBooleanInput("fail-if-item-not-found");
     const fullItem = await getItem(owner, projectNumber, item, field);
     if (!fullItem) {
-      core2.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core2.setFailed(`Item not found: ${item}`);
       return;
     }
     core2.setOutput("id", fullItem.id);

--- a/edit-item/README.md
+++ b/edit-item/README.md
@@ -20,6 +20,7 @@ Can not edit archived items due to a bug in the GitHub GraphQL API, see <https:/
 | `body`        | Body for the item - can only be set for draft issues. | No       |                                              |
 | `field`       | Project field to set on the item.                  | No       |                                              |
 | `field-value` | Value to set project field to.                     | No       |                                              |
+| `fail-if-item-not-found` | Should the action fail if the item is not found on the project | No      | `true` |
 
 ## Outputs
 

--- a/edit-item/action.yml
+++ b/edit-item/action.yml
@@ -29,6 +29,10 @@ inputs:
   field-value:
     description: Value to set project field to
     required: false
+  fail-if-item-not-found:
+    description: Should the action fail if the item is not found on the project
+    required: false
+    default: true
 
 outputs:
   id:

--- a/get-item/README.md
+++ b/get-item/README.md
@@ -17,6 +17,7 @@ Can not get archived items due to a bug in the GitHub GraphQL API, see <https://
 | `project-number` | The project number from the project's URL.         | Yes      |                                              |
 | `item`        | The item to get - may be the global ID for the item, the content ID, or the content URL. | No       | `${{ github.event.pull_request.html_url \|\| github.event.issue.html_url }}` |
 | `field`       | Project field to get on the item.                  | No       |                                              |
+| `fail-if-item-not-found` | Should the action fail if the item is not found on the project | No      | `true` |
 
 ## Outputs
 

--- a/get-item/action.yml
+++ b/get-item/action.yml
@@ -20,6 +20,10 @@ inputs:
   field:
     description: Project field to get on the item
     required: false
+  fail-if-item-not-found:
+    description: Should the action fail if the item is not found on the project
+    required: false
+    default: true
 
 outputs:
   id:

--- a/src/delete-item.ts
+++ b/src/delete-item.ts
@@ -9,11 +9,14 @@ export async function deleteItemAction(): Promise<void> {
     const projectNumber = core.getInput('project-number', { required: true });
     const item = core.getInput('item', { required: true });
 
+    // Optional inputs
+    const failIfItemNotFound = core.getBooleanInput('fail-if-item-not-found');
+
     // Item might be the item ID, the content ID, or the content URL
     const fullItem = await getItem(owner, projectNumber, item);
 
     if (!fullItem) {
-      core.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core.setFailed(`Item not found: ${item}`);
       return;
     }
 

--- a/src/edit-item.ts
+++ b/src/edit-item.ts
@@ -14,6 +14,7 @@ export async function editItemAction(): Promise<void> {
     const body = core.getInput('body');
     const field = core.getInput('field');
     const fieldValue = core.getInput('field-value', { required: !!field });
+    const failIfItemNotFound = core.getBooleanInput('fail-if-item-not-found');
 
     if (!!fieldValue && !field) {
       core.setFailed('Input required and not supplied: field');
@@ -24,7 +25,7 @@ export async function editItemAction(): Promise<void> {
     const fullItem = await getItem(owner, projectNumber, item);
 
     if (!fullItem) {
-      core.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core.setFailed(`Item not found: ${item}`);
       return;
     }
 

--- a/src/get-item.ts
+++ b/src/get-item.ts
@@ -11,12 +11,13 @@ export async function getItemAction(): Promise<void> {
 
     // Optional inputs
     const field = core.getInput('field') || undefined;
+    const failIfItemNotFound = core.getBooleanInput('fail-if-item-not-found');
 
     // Item might be the item ID, the content ID, or the content URL
     const fullItem = await getItem(owner, projectNumber, item, field);
 
     if (!fullItem) {
-      core.setFailed(`Item not found: ${item}`);
+      if (failIfItemNotFound) core.setFailed(`Item not found: ${item}`);
       return;
     }
 


### PR DESCRIPTION
Useful to have this option to avoid workflow failures when you don't care if the item is found (like deleting the item from a project).