### PR TITLE
ci: don't fail fast on integration tests matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - auth: PAT


### PR DESCRIPTION
Annoying to have the matrix jobs canceled if one fails due to a transient error.