### PR TITLE
fix: wait for draft issues to populate in copy project

### DIFF
--- a/__tests__/copy-project.test.mts
+++ b/__tests__/copy-project.test.mts
@@ -8,8 +8,10 @@ import {
   editItem,
   editProject,
   getDraftIssues,
+  getProject,
   linkProjectToRepository,
-  linkProjectToTeam
+  linkProjectToTeam,
+  ProjectDetails
 } from '../src/lib.js';
 import { mockGetBooleanInput, mockGetInput } from './utils.js';
 
@@ -231,6 +233,11 @@ describe('copyProjectAction', () => {
       'template-view': templateView
     });
     mockGetBooleanInput({ drafts: true });
+    vi.mocked(getProject).mockResolvedValue({
+      items: {
+        totalCount: 1
+      }
+    } as ProjectDetails);
     vi.mocked(getDraftIssues).mockResolvedValue([
       {
         id: 'item-id',
@@ -264,6 +271,11 @@ describe('copyProjectAction', () => {
       'template-view': templateView
     });
     mockGetBooleanInput({ drafts: true });
+    vi.mocked(getProject).mockResolvedValue({
+      items: {
+        totalCount: 1
+      }
+    } as ProjectDetails);
     vi.mocked(getDraftIssues).mockResolvedValue([
       {
         id: itemId,
@@ -302,6 +314,11 @@ describe('copyProjectAction', () => {
       'template-view': templateView
     });
     mockGetBooleanInput({ drafts: true });
+    vi.mocked(getProject).mockResolvedValue({
+      items: {
+        totalCount: 1
+      }
+    } as ProjectDetails);
     vi.mocked(getDraftIssues).mockResolvedValue([
       {
         id: itemId,


### PR DESCRIPTION
Something has changed on the GitHub side and now when copying a project it appears draft issues populate in an async manner so we need to wait for them before continuing with interpolation.