### PR TITLE
feat: add fail-if-project-not-found input

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -376,6 +376,15 @@ jobs:
           title: New Title ${{ steps.copy-project.outputs.number }}
           token: ${{ steps.get-auth-token.outputs.token }}
 
+      - name: Find Project (Not Found)
+        uses: ./find-project/
+        id: find-project-not-found
+        with:
+          fail-if-project-not-found: false
+          owner: ${{ matrix.owner }}
+          title: Foobar
+          token: ${{ steps.get-auth-token.outputs.token }}
+          
       - name: Confirm Project Found
         uses: ./github-script/
         with:
@@ -451,6 +460,15 @@ jobs:
           project-number: ${{ steps.copy-project.outputs.number }}
           token: ${{ steps.get-auth-token.outputs.token }}
 
+      - name: Close Project (Not Found)
+        uses: ./close-project/
+        id: close-project-not-found
+        with:
+          fail-if-project-not-found: false
+          owner: ${{ steps.copy-project.outputs.owner }}
+          project-number: 99999
+          token: ${{ steps.get-auth-token.outputs.token }}
+
       - name: Reopen Project
         uses: ./close-project/
         id: reopen-project
@@ -466,4 +484,13 @@ jobs:
         with:
           owner: ${{ steps.copy-project.outputs.owner }}
           project-number: ${{ steps.copy-project.outputs.number }}
+          token: ${{ steps.get-auth-token.outputs.token }}
+
+      - name: Delete Project (Not Found)
+        uses: ./delete-project/
+        id: delete-project-not-found
+        with:
+          fail-if-project-not-found: false
+          owner: ${{ steps.copy-project.outputs.owner }}
+          project-number: 99999
           token: ${{ steps.get-auth-token.outputs.token }}

--- a/__tests__/find-project.test.ts
+++ b/__tests__/find-project.test.ts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 
 import * as index from '../src/find-project';
 import { findProject } from '../src/lib';
-import { mockGetInput } from './utils';
+import { mockGetBooleanInput, mockGetInput } from './utils';
 
 vi.mock('@actions/core');
 vi.mock('../src/lib');
@@ -41,6 +41,7 @@ describe('findProjectAction', () => {
 
   it('handles project not found', async () => {
     mockGetInput({ owner, title });
+    mockGetBooleanInput({ 'fail-if-project-not-found': true });
     vi.mocked(findProject).mockResolvedValue(null);
 
     await index.findProjectAction();
@@ -50,6 +51,18 @@ describe('findProjectAction', () => {
     expect(core.setFailed).toHaveBeenLastCalledWith(
       `Project not found: ${title}`
     );
+  });
+
+  it('can ignore project not found', async () => {
+    mockGetInput({ owner, title });
+    mockGetBooleanInput({ 'fail-if-project-not-found': false });
+    vi.mocked(findProject).mockResolvedValue(null);
+
+    await index.findProjectAction();
+    expect(findProjectActionSpy).toHaveReturned();
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.setOutput).not.toHaveBeenCalled();
   });
 
   it('handles generic errors', async () => {

--- a/close-project/README.md
+++ b/close-project/README.md
@@ -16,6 +16,7 @@ Closing a project requires project admin permissions
 | `owner`       | The owner of the project - either an organization or a user. If not provided, it defaults to the repository owner. | No       | `${{ github.repository_owner }}`           |
 | `project-number` | The project number from the project's URL.         | Yes      |                                              |
 | `closed`       | Closed state of the project - set to `false` to reopen a closed project. | No       | `true`              |
+| `fail-if-project-not-found` | Should the action fail if the project is not found | No      | `true` |
 
 ## Outputs
 

--- a/close-project/action.yml
+++ b/close-project/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Closed state of the project - set false to reopen a closed project
     required: false
     default: true
+  fail-if-project-not-found:
+    description: Should the action fail if the project is not found
+    required: false
+    default: true
 
 outputs:
   id:

--- a/delete-project/README.md
+++ b/delete-project/README.md
@@ -15,6 +15,7 @@ Deleting a project requires project admin permissions
 | `token`       | A GitHub access token - either a classic PAT or a GitHub app installation token. | Yes      |                                              |
 | `owner`       | The owner of the project - either an organization or a user. If not provided, it defaults to the repository owner. | No       | `${{ github.repository_owner }}`           |
 | `project-number` | The project number from the project's URL.         | Yes      |                                              |
+| `fail-if-project-not-found` | Should the action fail if the project is not found | No      | `true` |
 
 ## Outputs
 

--- a/delete-project/action.yml
+++ b/delete-project/action.yml
@@ -13,6 +13,10 @@ inputs:
   project-number:
     description: The project number from the project's URL
     required: true
+  fail-if-project-not-found:
+    description: Should the action fail if the project is not found
+    required: false
+    default: true
 
 runs:
   using: node20

--- a/dist/close-project.js
+++ b/dist/close-project.js
@@ -21907,8 +21907,18 @@ async function closeProjectAction() {
     const owner = core2.getInput("owner", { required: true });
     const projectNumber = core2.getInput("project-number", { required: true });
     const closed = core2.getBooleanInput("closed");
-    const project = await closeProject(owner, projectNumber, closed);
-    core2.setOutput("id", project.id);
+    const failIfProjectNotFound = core2.getBooleanInput(
+      "fail-if-project-not-found"
+    );
+    try {
+      const project = await closeProject(owner, projectNumber, closed);
+      core2.setOutput("id", project.id);
+    } catch (error) {
+      if (error instanceof ProjectNotFoundError && !failIfProjectNotFound) {
+        return;
+      }
+      throw error;
+    }
   } catch (error) {
     if (error instanceof Error && error.stack) core2.debug(error.stack);
     core2.setFailed(

--- a/dist/delete-project.js
+++ b/dist/delete-project.js
@@ -19691,7 +19691,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput3(name, options);
@@ -19702,7 +19702,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports.getBooleanInput = getBooleanInput;
+    exports.getBooleanInput = getBooleanInput2;
     function setOutput(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -21900,7 +21900,17 @@ async function deleteProjectAction() {
   try {
     const owner = core2.getInput("owner", { required: true });
     const projectNumber = core2.getInput("project-number", { required: true });
-    await deleteProject(owner, projectNumber);
+    const failIfProjectNotFound = core2.getBooleanInput(
+      "fail-if-project-not-found"
+    );
+    try {
+      await deleteProject(owner, projectNumber);
+    } catch (error) {
+      if (error instanceof ProjectNotFoundError && !failIfProjectNotFound) {
+        return;
+      }
+      throw error;
+    }
   } catch (error) {
     if (error instanceof Error && error.stack) core2.debug(error.stack);
     core2.setFailed(

--- a/dist/find-project.js
+++ b/dist/find-project.js
@@ -19691,7 +19691,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput3(name, options);
@@ -19702,7 +19702,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports.getBooleanInput = getBooleanInput;
+    exports.getBooleanInput = getBooleanInput2;
     function setOutput2(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -21886,9 +21886,12 @@ async function findProjectAction() {
   try {
     const owner = core2.getInput("owner", { required: true });
     const title = core2.getInput("title", { required: true });
+    const failIfProjectNotFound = core2.getBooleanInput(
+      "fail-if-project-not-found"
+    );
     const project = await findProject(owner, title);
     if (!project) {
-      core2.setFailed(`Project not found: ${title}`);
+      if (failIfProjectNotFound) core2.setFailed(`Project not found: ${title}`);
       return;
     }
     core2.setOutput("closed", project.closed);

--- a/find-project/README.md
+++ b/find-project/README.md
@@ -11,6 +11,7 @@ Find a GitHub project
 | `token`           | A GitHub access token - either a classic PAT or a GitHub app installation token. | Yes      |                                              |
 | `owner`           | The owner of the project - either an organization or a user. If not provided, it defaults to the repository owner. | No       | `${{ github.repository_owner }}`           |
 | `title`           | The title of the project to find.         | Yes      |                                              |
+| `fail-if-project-not-found` | Should the action fail if the project is not found | No      | `true` |
 
 ## Outputs
 

--- a/find-project/action.yml
+++ b/find-project/action.yml
@@ -13,6 +13,10 @@ inputs:
   title:
     description: The title of the project to find
     required: true
+  fail-if-project-not-found:
+    description: Should the action fail if the project is not found
+    required: false
+    default: true
 
 outputs:
   id:

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "scripts": {
     "bundle": "npm run format:write && npm run package",
     "ci-test": "vitest run --coverage --reporter=verbose",
-    "format:write": "prettier --write \"**/*.ts\"",
-    "format:check": "prettier --check \"**/*.ts\"",
+    "format:write": "prettier --write \"**/*.{mts,ts}\"",
+    "format:check": "prettier --check \"**/*.{mts,ts}\"",
     "lint": "npx eslint . -c ./.github/linters/.eslintrc.yml",
     "package:add-item": "esbuild add-item/index.ts --bundle --format=esm --outfile=dist/add-item.js --platform=node --target=node20.2 --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\"",
     "package:archive-item": "esbuild archive-item/index.ts --bundle --format=esm --outfile=dist/archive-item.js --platform=node --target=node20.2 --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\"",

--- a/src/find-project.ts
+++ b/src/find-project.ts
@@ -8,10 +8,15 @@ export async function findProjectAction(): Promise<void> {
     const owner = core.getInput('owner', { required: true });
     const title = core.getInput('title', { required: true });
 
+    // Optional inputs
+    const failIfProjectNotFound = core.getBooleanInput(
+      'fail-if-project-not-found'
+    );
+
     const project = await findProject(owner, title);
 
     if (!project) {
-      core.setFailed(`Project not found: ${title}`);
+      if (failIfProjectNotFound) core.setFailed(`Project not found: ${title}`);
       return;
     }
 


### PR DESCRIPTION
Useful to have this option to avoid workflow failures when you don't care if the project is found (deleting a project).