### PR TITLE
feat: find closed projects

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -467,6 +467,14 @@ jobs:
           fail-if-project-not-found: false
           owner: ${{ steps.copy-project.outputs.owner }}
           project-number: 99999
+
+      - name: Find Closed Project
+        uses: ./find-project/
+        id: find-closed-project
+        with:
+          owner: ${{ steps.copy-project.outputs.owner }}
+          title: ${{ steps.copy-project.outputs.title }}
+          include-closed: true
           token: ${{ steps.get-auth-token.outputs.token }}
 
       - name: Reopen Project

--- a/__tests__/find-project.test.ts
+++ b/__tests__/find-project.test.ts
@@ -22,6 +22,27 @@ const title = 'My Title';
 const readme = 'README';
 const url = 'url';
 
+const mockProject = {
+  id: projectId,
+  number: parseInt(projectNumber),
+  fields: {
+    totalCount: fieldCount
+  },
+  items: {
+    totalCount: itemCount
+  },
+  url,
+  title,
+  readme,
+  shortDescription,
+  public: true,
+  closed: false,
+  owner: {
+    type: 'Organization' as const,
+    login: owner
+  }
+};
+
 describe('findProjectAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,28 +112,31 @@ describe('findProjectAction', () => {
     expect(core.setFailed).toHaveBeenLastCalledWith('42');
   });
 
+  it('finds closed projects', async () => {
+    mockGetInput({ owner, title });
+    mockGetBooleanInput({ 'include-closed': true });
+    vi.mocked(findProject).mockResolvedValue(mockProject);
+
+    await index.findProjectAction();
+    expect(findProjectActionSpy).toHaveReturned();
+
+    expect(findProject).toHaveBeenCalledWith(owner, title, true, '');
+  });
+
+  it('can set limit', async () => {
+    mockGetInput({ owner, title, limit: '50' });
+    mockGetBooleanInput({});
+    vi.mocked(findProject).mockResolvedValue(mockProject);
+
+    await index.findProjectAction();
+    expect(findProjectActionSpy).toHaveReturned();
+
+    expect(findProject).toHaveBeenCalledWith(owner, title, false, '50');
+  });
+
   it('sets output', async () => {
     mockGetInput({ owner, title });
-    vi.mocked(findProject).mockResolvedValue({
-      id: projectId,
-      number: parseInt(projectNumber),
-      fields: {
-        totalCount: fieldCount
-      },
-      items: {
-        totalCount: itemCount
-      },
-      url,
-      title,
-      readme,
-      shortDescription,
-      public: true,
-      closed: false,
-      owner: {
-        type: 'Organization',
-        login: owner
-      }
-    });
+    vi.mocked(findProject).mockResolvedValue(mockProject);
 
     await index.findProjectAction();
     expect(findProjectActionSpy).toHaveReturned();

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -1330,12 +1330,39 @@ describe('lib', () => {
       ).resolves.toEqual(null);
     });
 
+    it('can include closed projects', async () => {
+      vi.mocked(execCliCommand).mockResolvedValue(
+        JSON.stringify({ projects: [project] })
+      );
+      await expect(lib.findProject(owner, projectTitle, true)).resolves.toEqual(
+        project
+      );
+      expect(execCliCommand).toHaveBeenCalledWith(
+        expect.arrayContaining(['--closed'])
+      );
+    });
+
+    it('can set a limit', async () => {
+      vi.mocked(execCliCommand).mockResolvedValue(
+        JSON.stringify({ projects: [project] })
+      );
+      await expect(
+        lib.findProject(owner, projectTitle, false, '50')
+      ).resolves.toEqual(project);
+      expect(execCliCommand).toHaveBeenCalledWith(
+        expect.arrayContaining(['--limit'])
+      );
+    });
+
     it('returns project details', async () => {
       vi.mocked(execCliCommand).mockResolvedValue(
         JSON.stringify({ projects: [project] })
       );
       await expect(lib.findProject(owner, projectTitle)).resolves.toEqual(
         project
+      );
+      expect(execCliCommand).not.toHaveBeenCalledWith(
+        expect.arrayContaining(['--limit'])
       );
     });
   });

--- a/dist/find-project.js
+++ b/dist/find-project.js
@@ -21862,17 +21862,15 @@ var PROJECT_WORKFLOWS_QUERY = `
       }
     }
   }`;
-async function findProject(owner, title) {
-  const { projects } = JSON.parse(
-    await execCliCommand([
-      "project",
-      "list",
-      "--owner",
-      owner,
-      "--format",
-      "json"
-    ])
-  );
+async function findProject(owner, title, closed = false, limit) {
+  const args = ["project", "list", "--owner", owner, "--format", "json"];
+  if (closed) {
+    args.push("--closed");
+  }
+  if (limit) {
+    args.push("--limit", limit);
+  }
+  const { projects } = JSON.parse(await execCliCommand(args));
   for (const project of projects) {
     if (project.title === title) {
       return project;
@@ -21889,7 +21887,9 @@ async function findProjectAction() {
     const failIfProjectNotFound = core2.getBooleanInput(
       "fail-if-project-not-found"
     );
-    const project = await findProject(owner, title);
+    const includeClosed = core2.getBooleanInput("include-closed");
+    const limit = core2.getInput("limit");
+    const project = await findProject(owner, title, includeClosed, limit);
     if (!project) {
       if (failIfProjectNotFound) core2.setFailed(`Project not found: ${title}`);
       return;

--- a/dist/github-script/index.js
+++ b/dist/github-script/index.js
@@ -40518,16 +40518,15 @@ async function editProject(owner, projectNumber, edit) {
     }
     return JSON.parse(output).id;
 }
-async function findProject(owner, title) {
-    // TODO - Pagination
-    const { projects } = JSON.parse(await helpers_execCliCommand([
-        'project',
-        'list',
-        '--owner',
-        owner,
-        '--format',
-        'json'
-    ]));
+async function findProject(owner, title, closed = false, limit) {
+    const args = ['project', 'list', '--owner', owner, '--format', 'json'];
+    if (closed) {
+        args.push('--closed');
+    }
+    if (limit) {
+        args.push('--limit', limit);
+    }
+    const { projects } = JSON.parse(await helpers_execCliCommand(args));
     for (const project of projects) {
         if (project.title === title) {
             return project;

--- a/find-project/README.md
+++ b/find-project/README.md
@@ -10,6 +10,8 @@ Find a GitHub project
 |-------------------|----------------------------------------------------|----------|----------------------------------------------|
 | `token`           | A GitHub access token - either a classic PAT or a GitHub app installation token. | Yes      |                                              |
 | `owner`           | The owner of the project - either an organization or a user. If not provided, it defaults to the repository owner. | No       | `${{ github.repository_owner }}`           |
+| `include-closed`  | Include closed projects.                  | No       | `false` |
+| `limit`           | Maximum number of projects to fetch.      | No       | 30 |
 | `title`           | The title of the project to find.         | Yes      |                                              |
 | `fail-if-project-not-found` | Should the action fail if the project is not found | No      | `true` |
 

--- a/find-project/action.yml
+++ b/find-project/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: Should the action fail if the project is not found
     required: false
     default: true
+  include-closed:
+    description: Include closed projects
+    required: false
+    default: false
+  limit:
+    description: Maximum number of projects to fetch
+    required: false
+    default: 30
 
 outputs:
   id:

--- a/src/find-project.ts
+++ b/src/find-project.ts
@@ -12,8 +12,10 @@ export async function findProjectAction(): Promise<void> {
     const failIfProjectNotFound = core.getBooleanInput(
       'fail-if-project-not-found'
     );
+    const includeClosed = core.getBooleanInput('include-closed');
+    const limit = core.getInput('limit');
 
-    const project = await findProject(owner, title);
+    const project = await findProject(owner, title, includeClosed, limit);
 
     if (!project) {
       if (failIfProjectNotFound) core.setFailed(`Project not found: ${title}`);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -901,19 +901,21 @@ export async function editProject(
 
 export async function findProject(
   owner: string,
-  title: string
+  title: string,
+  closed = false,
+  limit?: string
 ): Promise<ProjectDetails | null> {
-  // TODO - Pagination
-  const { projects } = JSON.parse(
-    await execCliCommand([
-      'project',
-      'list',
-      '--owner',
-      owner,
-      '--format',
-      'json'
-    ])
-  );
+  const args = ['project', 'list', '--owner', owner, '--format', 'json'];
+
+  if (closed) {
+    args.push('--closed');
+  }
+
+  if (limit) {
+    args.push('--limit', limit);
+  }
+
+  const { projects } = JSON.parse(await execCliCommand(args));
 
   for (const project of projects) {
     if (project.title === title) {


### PR DESCRIPTION
Adds `include-closed` and `limit` inputs to the find project action so that closed projects can be searched and the limit can be bumped as needed.